### PR TITLE
Change type of duration variable `ms` in yocto_buzzer.py

### DIFF
--- a/Sources/yocto_buzzer.py
+++ b/Sources/yocto_buzzer.py
@@ -394,7 +394,7 @@ class YBuzzer(YFunction):
                     num = prevDuration
                 else:
                     prevDuration = num
-                ms = round(320000.0 / (tempo * num))
+                ms = int(round(320000.0 / (tempo * num)))
                 if typ == 0:
                     self.addPulseToPlaySeq(0, ms)
                 else:


### PR DESCRIPTION
This fixes the following error if `playNotes` is called with a Yocto-Buzzer module.
```
----> 1 buzzer.playNotes("C 'C")

Sources/yocto_buzzer.py in playNotes(self, notes)
    522         """
    523         self.resetPlaySeq()
--> 524         self.addNotesToPlaySeq(notes)
    525         return self.oncePlaySeq()
    526 

Sources/yocto_buzzer.py in addNotesToPlaySeq(self, notes)
    406                     pitch = prevPitch + dNote
    407                     freq = round(440 * math.exp(pitch * 0.05776226504666))
--> 408                     ms16 = ((ms) >> (4))
    409                     rest = 0
    410                     if typ == 3:

TypeError: unsupported operand type(s) for >>: 'float' and 'int'
```