### PR TITLE
Correct volume attribute name in set_volume setter

### DIFF
--- a/Sources/yocto_buzzer.py
+++ b/Sources/yocto_buzzer.py
@@ -153,7 +153,7 @@ class YBuzzer(YFunction):
         On failure, throws an exception or returns a negative error code.
         """
         rest_val = str(newval)
-        return self._setAttr("volume", rest_val)
+        return self._setAttr("_volume", rest_val)
 
     def get_playSeqSize(self):
         """


### PR DESCRIPTION
I run into some issues with the volume not updated and even being 0 after having called the function set_volume from the yoctopuce_buzzer.

After some tinkering, I realised that the "volume" attribute did not exist but the "_volume" did exist. After changing the string parameter for the attribute name it did work.

 This may also be linked to how the _setAttr method work.